### PR TITLE
Option for additional variables to be plotted within exclude function

### DIFF
--- a/R/Quality_checking.R
+++ b/R/Quality_checking.R
@@ -1038,8 +1038,7 @@ fetch_filter <- function(x, fetch_name, wd_name, ROI_boundary, name_out = "-") {
 #'
 #' @return An integer vector with attributes \code{"varnames"} and
 #'   \code{"units"}.
-exclude<-function (x, qc_x = NULL, name_out = "-", win_size = 672, other1 = NULL, other2 = NULL, other3 = NULL, col1 = NULL, col2 = NULL, col3 = NULL) 
-{
+exclude<-function (x, qc_x = NULL, name_out = "-", win_size = 672, other1 = NULL, other2 = NULL, other3 = NULL, col1 = NULL, col2 = NULL, col3 = NULL) {
   if(!exists("other1")) other1 = NA
   if(!exists("other2")) other2 = NA
   if(!exists("other3")) other3 = NA

--- a/R/Quality_checking.R
+++ b/R/Quality_checking.R
@@ -1,4 +1,4 @@
-#' Apply Thresholds
+﻿#' Apply Thresholds
 #'
 #' Values of \code{x} are checked against two specified thresholds to obtain
 #' their quality control (QC) flags.
@@ -1032,9 +1032,9 @@ fetch_filter <- function(x, fetch_name, wd_name, ROI_boundary, name_out = "-") {
 #' @param other1 A numeric vector of the same length as \code{x} with the first additional variable to be plotted
 #' @param other2 A numeric vector of the same length as \code{x} with the second additional variable to be plotted
 #' @param other3 A numeric vector of the same length as \code{x} with the third additional variable to be plotted
-#' @param col1 A character assignig a colour for \code{other1}
-#' @param col2 A character assignig a colour for \code{other2}
-#' @param col3 A character assignig a colour for \code{other3}
+#' @param col1 A character assigning a colour for \code{other1}
+#' @param col2 A character assigning a colour for \code{other2}
+#' @param col3 A character assigning a colour for \code{other3}
 #'
 #' @return An integer vector with attributes \code{"varnames"} and
 #'   \code{"units"}.


### PR DESCRIPTION
Hi Lada,
this is just a suggestions and probably not the final solution. I personally found very useful to have some additional variables in the plot when performing manual data screening. For instance, when filtering H, I add Rn and LE,  when filtering LE, I add Rn and H, or when filtering NEE I add PAR (divided e.g. by -100 to get it into the comparable scale - that can be done by user just in the arguments of the `exclude` function). It seems to be very hard  to manually filter the variable without seeing any additional variables or track them in the external pdf files.

The calls of the `exclude` function can look e.g. like as follows:

```
excl_H <- exclude(site$H, H_prelim, "qc_H_man", other1 = M$Rn, other2 = ifelse(LE_prelim==2,NA,site$LE), col1 = 'grey', col2 = 'blue')
excl_LE <- exclude(site$LE, LE_prelim, "qc_LE_man", other1 = M$Rn, other2 = ifelse(H_prelim==2,NA,site$H), col1 = 'grey', col2 = 'violet')
excl_NEE <- exclude(site$NEE, NEE_prelim, "qc_NEE_man", other1 = -M$PAR/100, col1 = 'blue')
```

So far, I found the manual filtering a necessary step especially for H during the winter time - at least that measured by HS-50 sonic anemometer.

Cheers,
Milan

